### PR TITLE
ASM-3406 remove asm_decrypt password encryption

### DIFF
--- a/lib/puppet/util/network_device/ciscoucs/device.rb
+++ b/lib/puppet/util/network_device/ciscoucs/device.rb
@@ -2,8 +2,6 @@ require 'puppet/util/network_device'
 require 'puppet/util/network_device/ciscoucs/facts'
 require 'uri'
 require 'net/https'
-require '/etc/puppetlabs/puppet/modules/asm_lib/lib/security/encode'
-
 
 module_lib = Pathname.new(__FILE__).parent.parent.parent.parent.parent
 require File.join module_lib.to_s, '/puppet_x/puppetlabs/transportciscoucs'
@@ -35,7 +33,7 @@ module Puppet::Util::NetworkDevice::Ciscoucs
       password = text[0,pos]
       @host = text[pos+1, length]
       @user = URI.decode(username)
-	  @password = URI.decode(asm_decrypt(password))
+	    @password = URI.decode(password)
     end
 
     def facts

--- a/lib/puppet_x/puppetlabs/transportciscoucs/ciscoucs.rb
+++ b/lib/puppet_x/puppetlabs/transportciscoucs/ciscoucs.rb
@@ -1,6 +1,4 @@
 require 'puppet_x/puppetlabs/transportciscoucs/authenticate'
-require '/etc/puppetlabs/puppet/modules/asm_lib/lib/security/encode'
-
 
 module PuppetX::Puppetlabs::Transportciscoucs
   # "Base class for ciscoucs"


### PR DESCRIPTION
An encrypted device password was passed to the asm-deployer device
management service and written to the device configuration file
url. That password has been deprecated and all puppet-layer code
should use the credential_id argument in preference to that.